### PR TITLE
change spacing variables based on sweco grid system

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -188,6 +188,13 @@ export const theme = createTheme({
     inset:
       "inset 0 .6px 1.8px var(--sweco-shadow-color-1a), inset 0 3.2px 7.2px var(--sweco-shadow-color-1b)",
   },
+  spacing: {
+    xs: "0.125rem",
+    sm: "0.5rem",
+    md: "1rem",
+    lg: "1.5rem",
+    xl: "2rem",
+  },
   components: {
     Mark: Mark.extend({
       defaultProps: {


### PR DESCRIPTION
Enligt sweco grid system:
_"The 8 px grid system offers a simple, scalable solution to these challenges. By using multiples of 8 (e.g. 8, 16, 24, 32, 40, 48, 56, etc.) for sizing, spacing, padding, and margins, the system ensures consistency and efficiency across a wide range of devices. The grid system can also scale down for finer adjustments. If you need more precision for tighter spaces, you can use smaller increments like 2 or 4 px, allowing for more detailed control without sacrificing the overall consistency of the design."_

La därför till följande
xs: 2px
sm: 8
md: 16
lg: 24
xl: 32